### PR TITLE
On change value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.10](https://github.com/cdeutsch/classy-forms/compare/v0.0.9...v0.0.10) (2020-02-12)
+
+Added `onChangeValue` helper, so frameworks that use a non-native `<select>` don't have to create a fake `event`.
+
+
 ### [0.0.9](https://github.com/cdeutsch/classy-forms/compare/v0.0.8...v0.0.9) (2020-02-12)
 
 Support `HTMLSelectElement` and `HTMLTextAreaElement` in `onChange` and `onBlur`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -9,6 +9,7 @@ import {
   FormsContextContext,
   FormsProviderProps,
   ValidationResult,
+  Value,
 } from './interfaces';
 import { validations } from './validations';
 
@@ -39,6 +40,7 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
         ...formField,
         onChange: this.onChange.bind(this, key),
         onBlur: this.onBlur.bind(this, key),
+        onChangeValue: this.onChangeValue.bind(this, key),
       };
     });
 
@@ -53,12 +55,12 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
     return <FormsContext.Provider value={this.state}>{this.props.children}</FormsContext.Provider>;
   }
 
-  onChange = (name: string, event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+  onChangeValue = (name: string, value: Value) => {
     const { formFields } = this.state;
     const formField = formFields[name];
 
-    if (formField && formField.value !== event.target.value) {
-      formField.value = event.target.value;
+    if (formField && formField.value !== value) {
+      formField.value = value;
       formField.dirty = true;
 
       // Validate immediately only if there are errors.
@@ -72,7 +74,11 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
     }
   };
 
-  onBlur = (name: string, event: React.FocusEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+  onChange = (name: string, event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    this.onChangeValue(name, event.target.value);
+  };
+
+  onBlur = (name: string) => {
     const { formFields } = this.state;
 
     const validationResult = validateFormFields(formFields, this.props.formFieldConfigs, false, name);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,7 +71,8 @@ export interface FormField {
 
 export interface FormFieldWithHelpers extends FormField {
   onChange(event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>): void;
-  onBlur(event: React.FocusEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>): void;
+  onBlur(): void;
+  onChangeValue(value: Value): void;
 }
 
 export type FormFields<T extends object = any> = Record<Extract<keyof T, string>, FormField>;


### PR DESCRIPTION
Added `onChangeValue` helper, so frameworks that use a non-native `<select>` don't have to create a fake `event`.