### PR TITLE
helperText and invalidText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.0.13](https://github.com/cdeutsch/classy-forms/compare/v0.0.12...v0.0.13) (2020-02-26)
+
+Add `invalidText` and `helperText` config options.
+
+`invalidText` allows you to set the helper text displayed on error. Overridden by getHelperText if both exist.
+
+`helperText` allows you to set the helper text always displayed, but is overridden by invalidText when invalid, and getHelperText if both exist.
+
+
 ### [0.0.12](https://github.com/cdeutsch/classy-forms/compare/v0.0.11...v0.0.12) (2020-02-24)
 
 Fix the reset functionality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -278,6 +278,10 @@ function validateAndDetectChanges(
   formField.errors = errors.sort();
 
   const origHelperText = formField.helperText;
+  formField.helperText = formFieldConfig.helperText;
+  if (formField.hasError && formFieldConfig.invalidText) {
+    formField.helperText = formFieldConfig.invalidText;
+  }
   if (formFieldConfig.getHelperText) {
     formField.helperText = formFieldConfig.getHelperText(formField, submitting);
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -29,6 +29,8 @@ export interface FormFieldConfig {
   value?: Value;
   label?: string;
   validateOnChange?: boolean;
+  helperText?: string; // Helper text to display. Overridden by invalidText when invalid, and getHelperText if both exist.
+  invalidText?: string; // Helper text displayed on error. Overridden by getHelperText if both exist.
   // error?: boolean;
   // dirty?: boolean;
 


### PR DESCRIPTION
Add `invalidText` and `helperText` config options.

`invalidText` allows you to set the helper text displayed on error. Overridden by getHelperText if both exist.

`helperText` allows you to set the helper text always displayed, but is overridden by invalidText when invalid, and getHelperText if both exist.