### PR TITLE
Dirty improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.0](https://github.com/cdeutsch/classy-forms/compare/v0.0.13...v0.0.14) (2020-03-05)
+
+Add two ways to calculate `dirty`.
+
+`OnChange` will immediately be dirty and stay dirty as soon as the value changes.
+
+`NotEqual` will only be dirty if the value is differently than the defaulted `initValue`, and can change over time.
+
+Add `defaultInitValue` because we're using this logic in 3 places now and I can see it changing in the future, since we may not want to default all null values to a string.
+
+Add `isEqual` option so you can do a "deep equal" to set the `dirty` flag if desired.
+
+BREAKING CHANGE:
+
+Rename `formFieldConfig.value` to `formFieldConfig.initValue` to better clarify what it does.
+
+As `value` it implies if you change it later it will do something, when in reality it does not.
+
+
 ### [0.0.13](https://github.com/cdeutsch/classy-forms/compare/v0.0.12...v0.0.13) (2020-02-26)
 
 Add `invalidText` and `helperText` config options.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -19,6 +19,10 @@ export const FormsContext = React.createContext<FormsContextContext>({
   onSubmit: () => {},
   // tslint:disable-next-line: no-empty
   reset: () => {},
+  // tslint:disable-next-line: no-empty
+  isDirty: () => {
+    return false;
+  },
 });
 
 export const FormsConsumer = FormsContext.Consumer;
@@ -48,6 +52,7 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
       formFields: formFieldsWithHelpers,
       onSubmit: this.onSubmit,
       reset: this.reset,
+      isDirty: this.isDirty,
     };
   }
 
@@ -57,16 +62,24 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
 
   onChangeValue = (name: string, value: Value) => {
     const { formFields } = this.state;
+    const { formFieldConfigs, options } = this.props;
     const formField = formFields[name];
 
     if (formField && formField.value !== value) {
+      const formFieldConfig = getFormFieldConfig(name, formFieldConfigs);
+
       formField.value = value;
-      formField.dirty = true;
+
+      // Calculate `dirty` based on `dirtyMode`.
+      if (options?.dirtyMode === 'OnChange') {
+        formField.dirty = true;
+      } else {
+        formField.dirty = defaultInitValue(formFieldConfig) !== formField.value;
+      }
 
       // Validate immediately only if there are errors or validateOnChange is true.
-      const formFieldConfig = getFormFieldConfig(name, this.props.formFieldConfigs);
       if (formField.hasError || formFieldConfig.validateOnChange) {
-        validateFormFields(formFields, this.props.formFieldConfigs, false, name);
+        validateFormFields(formFields, formFieldConfigs, false, name);
       }
 
       this.setState({
@@ -123,12 +136,19 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
       formField.dirty = false;
       formField.errors = [];
       formField.hasError = false;
-      formField.value = formFieldConfig.initValue || '';
+      formField.value = defaultInitValue(formFieldConfig);
     });
 
     this.setState({
       formFields: formFields,
     });
+  };
+
+  isDirty = () => {
+    // Reset form fields to their original state.
+    const { formFields } = this.state;
+
+    return Object.keys(formFields).every((name) => !formFields[name].dirty);
   };
 }
 
@@ -136,7 +156,7 @@ export function createFormField(formFieldConfig: FormFieldConfig): FormField {
   // Convert formFieldConfigs to formField.
   return {
     name: formFieldConfig.name,
-    value: formFieldConfig.initValue || '',
+    value: defaultInitValue(formFieldConfig),
     // TODO: decide if setting the init value for hasError, etc is necessary.
     // hasError: formFieldConfig.hasError || false,
     // errors: formFieldConfig.errors || false,
@@ -294,6 +314,10 @@ function validateAndDetectChanges(
     origHelperText !== formField.helperText ||
     !arraysEqual(origErrors, formField.errors)
   );
+}
+
+export function defaultInitValue(formFieldConfig: FormFieldConfig): Value {
+  return formFieldConfig.initValue ?? '';
 }
 
 export function getFormFieldConfig(name: string, formFieldConfigs: FormFieldConfig[]): FormFieldConfig {

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -74,7 +74,11 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
       if (options?.dirtyMode === 'OnChange') {
         formField.dirty = true;
       } else {
-        formField.dirty = defaultInitValue(formFieldConfig) !== formField.value;
+        if (options?.isEqual) {
+          formField.dirty = options.isEqual(defaultInitValue(formFieldConfig), formField.value);
+        } else {
+          formField.dirty = defaultInitValue(formFieldConfig) !== formField.value;
+        }
       }
 
       // Validate immediately only if there are errors or validateOnChange is true.

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -27,7 +27,7 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
   constructor(props: FormsProviderProps) {
     super(props);
 
-    // Create formFields or using initial.
+    // Create formFields or use initial.
     const formFields = props.initFormFields || createFormFields(props.formFieldConfigs);
 
     // Augment FormFields with events (helpers).
@@ -123,7 +123,7 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
       formField.dirty = false;
       formField.errors = [];
       formField.hasError = false;
-      formField.value = formFieldConfig.value || '';
+      formField.value = formFieldConfig.initValue || '';
     });
 
     this.setState({
@@ -136,7 +136,7 @@ export function createFormField(formFieldConfig: FormFieldConfig): FormField {
   // Convert formFieldConfigs to formField.
   return {
     name: formFieldConfig.name,
-    value: formFieldConfig.value || '',
+    value: formFieldConfig.initValue || '',
     // TODO: decide if setting the init value for hasError, etc is necessary.
     // hasError: formFieldConfig.hasError || false,
     // errors: formFieldConfig.errors || false,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -26,7 +26,7 @@ export type ErrorType =
 
 export interface FormFieldConfig {
   name: string;
-  value?: Value;
+  initValue?: Value;
   label?: string;
   validateOnChange?: boolean;
   helperText?: string; // Helper text to display. Overridden by invalidText when invalid, and getHelperText if both exist.

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -31,6 +31,10 @@ export interface FormOptions {
    * Mode to use when calculating `dirty`. Default is `NotEqual`.
    */
   dirtyMode?: DirtyMode;
+  /**
+   * Function to use to compare equality. Used to calculate `dirty`.
+   */
+  isEqual?(valueA: Value, valueB: Value): boolean;
 }
 
 export interface FormFieldConfig {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -24,6 +24,15 @@ export type ErrorType =
   | 'required'
   | 'isValid';
 
+export type DirtyMode = 'NotEqual' | 'OnChange';
+
+export interface FormOptions {
+  /**
+   * Mode to use when calculating `dirty`. Default is `NotEqual`.
+   */
+  dirtyMode?: DirtyMode;
+}
+
 export interface FormFieldConfig {
   name: string;
   initValue?: Value;
@@ -85,6 +94,7 @@ export type FormFieldsWithHelpers<T extends object = any> = Record<Extract<keyof
 export interface FormsProviderProps<T extends object = any> {
   formFieldConfigs: FormFieldConfig[];
   initFormFields?: FormFields<T>;
+  options?: FormOptions;
   onSubmit?(event: React.FormEvent<HTMLFormElement>, formFields: FormFieldsWithHelpers<T>): void;
 }
 
@@ -93,6 +103,7 @@ export interface FormsContextContext<T extends object = any> {
 
   onSubmit(event: React.FormEvent<HTMLFormElement>): void;
   reset(): void;
+  isDirty(): boolean;
 }
 
 export interface ValidationResult {


### PR DESCRIPTION
Add two ways to calculate `dirty`.

`OnChange` will immediately be dirty and stay dirty as soon as the value changes.

`NotEqual` will only be dirty if the value is differently than the defaulted `initValue`, and can change over time.

Add `defaultInitValue` because we're using this logic in 3 places now and I can see it changing in the future, since we may not want to default all null values to a string.

Add `isEqual` option so you can do a "deep equal" to set the `dirty` flag if desired.

BREAKING CHANGE:

Rename `formFieldConfig.value` to `formFieldConfig.initValue` to better clarify what it does.

As `value` it implies if you change it later it will do something, when in reality it does not.