### PR TITLE
Remove new esnext code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.2](https://github.com/cdeutsch/classy-forms/compare/v0.1.1...v0.1.2) (2020-03-05)
+
+Remove optional chaining and nullish coalescing operator because TypeScript targeting `esnext` won't transpile them, and a lot of Webpack configs aren't ready to handle them 🙄
+
+
 ### [0.1.1](https://github.com/cdeutsch/classy-forms/compare/v0.1.0...v0.1.1) (2020-03-05)
 
 Upgrade NPMs, particularly TypeScript to fix the library breaking bug due to using new features that don't exist in the previous version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -71,10 +71,10 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsCont
       formField.value = value;
 
       // Calculate `dirty` based on `dirtyMode`.
-      if (options?.dirtyMode === 'OnChange') {
+      if (options && options.dirtyMode === 'OnChange') {
         formField.dirty = true;
       } else {
-        if (options?.isEqual) {
+        if (options && options.isEqual) {
           formField.dirty = options.isEqual(defaultInitValue(formFieldConfig), formField.value);
         } else {
           formField.dirty = defaultInitValue(formFieldConfig) !== formField.value;
@@ -321,7 +321,8 @@ function validateAndDetectChanges(
 }
 
 export function defaultInitValue(formFieldConfig: FormFieldConfig): Value {
-  return formFieldConfig.initValue ?? '';
+  // return formFieldConfig.initValue ?? '';
+  return formFieldConfig.initValue == null ? '' : formFieldConfig.initValue;
 }
 
 export function getFormFieldConfig(name: string, formFieldConfigs: FormFieldConfig[]): FormFieldConfig {


### PR DESCRIPTION
Remove optional chaining and nullish coalescing operator because TypeScript targeting `esnext` won't transpile them, and a lot of Webpack configs aren't ready to handle them 🙄