### PR TITLE
Form fields to object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.5](https://github.com/cdeutsch/classy-forms/compare/v0.1.4...v0.1.5) (2020-03-12)
+
+Added `formFieldsToObject` to aid in converting a `FormField` record into a plain old object.
+
+
 ### [0.1.4](https://github.com/cdeutsch/classy-forms/compare/v0.1.3...v0.1.4) (2020-03-09)
 
 Always run the onChange logic.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -368,3 +368,14 @@ export function validateFormFields(
     stateModified: stateModified,
   };
 }
+
+export function formFieldsToObject<T extends object = any>(formFields: FormFields<T>) {
+  return Object.keys(formFields).reduce<T>(
+    (accumulator, key) => ({
+      ...accumulator,
+      [key as Extract<keyof T, string>]: formFields[key as Extract<keyof T, string>].value,
+    }),
+    // tslint:disable-next-line: no-object-literal-type-assertion
+    {} as T
+  );
+}


### PR DESCRIPTION
Added `formFieldsToObject` to aid in converting a `FormField` record into a plain old object.