### PR TITLE
Significant Refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.2.0](https://github.com/cdeutsch/classy-forms/compare/v0.1.12...v0.2.0) (2020-03-17)
+
+Add `formKey` Provider property that can be used to reset the internal formFields state and re-run validation. Useful after making an async call to update the database and you want to reset the dirty flags, etc.
+
+Update `FormField` interface so it only contains properties that need to be managed in "state". Move the other properties to `FormFieldHelpers`
+
+Update `FormsProvider` so it will look for `formKey` changes and re-run what we do in the constructor.
+
+Added `updateFormFieldConfigs` flag to `validateFormFields` which can be used in server-side rendering scenarios to copy the results of the validation back to `formFieldConfigs` so they can be used to initialize the `FormsProvider`.
+
+Add `hasError`, `errors`, and `dirty` to `FormFieldConfig` so consumer can manually control the overall Form state.
+
+### ⚠ BREAKING CHANGES:
+
+- Rename `createFormFields` to `initializeFormFields` so it better reflects what it does. The new `createFormFields` is now responsible for combining `FormFieldConfig` properties with `FormFieldState` to make in convenient to access all FormField related properties in one object.
+
+- Change `getHelperText` signature so it's consistent with `isValid`.
+
+- Renamed `FormFieldWithHelpers` to `FormFieldAndEventHelpers`, and `FormFieldsWithHelpers` to `FormFieldsWithEventHelpers`
+
+
 ### [0.1.12](https://github.com/cdeutsch/classy-forms/compare/v0.1.11...v0.1.12) (2020-03-16)
 
 Pass `reset` and `isDirty` when `onSubmit` is called.
@@ -76,7 +97,7 @@ Add `defaultInitValue` because we're using this logic in 3 places now and I can 
 
 Add `isEqual` option so you can do a "deep equal" to set the `dirty` flag if desired.
 
-BREAKING CHANGE:
+### ⚠ BREAKING CHANGES:
 
 Rename `formFieldConfig.value` to `formFieldConfig.initValue` to better clarify what it does.
 

--- a/demo/tslint.json
+++ b/demo/tslint.json
@@ -24,7 +24,7 @@
     "no-dynamic-delete": false,
     "no-empty-interface": false,
     "no-function-expression": false,
-    // TODO: allow devDependencies only in **/*.spec.ts files:
+    // SOMEDAY: allow devDependencies only in **/*.spec.ts files:
     // waiting on https://github.com/palantir/tslint/pull/3708
     "no-implicit-dependencies": false,
     "no-import-side-effect": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.1.12",
+  "version": "0.2.0",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/ClassyForm.tsx
+++ b/src/ClassyForm.tsx
@@ -12,10 +12,11 @@ export interface ClassyFormProps<P = {}>
 
 export class ClassyForm extends React.Component<ClassyFormProps> {
   render() {
-    const { children, formFieldConfigs, initFormFields, onSubmit, options, ...passthrough } = this.props;
+    const { children, formFieldConfigs, formKey, initFormFields, onSubmit, options, ...passthrough } = this.props;
 
     return (
       <FormsProvider
+        formKey={formKey}
         formFieldConfigs={formFieldConfigs}
         initFormFields={initFormFields}
         options={options}

--- a/src/ClassyForm.tsx
+++ b/src/ClassyForm.tsx
@@ -12,16 +12,10 @@ export interface ClassyFormProps<P = {}>
 
 export class ClassyForm extends React.Component<ClassyFormProps> {
   render() {
-    const { children, formFieldConfigs, formKey, initFormFields, onSubmit, options, ...passthrough } = this.props;
+    const { children, formFieldConfigs, formKey, onSubmit, options, ...passthrough } = this.props;
 
     return (
-      <FormsProvider
-        formKey={formKey}
-        formFieldConfigs={formFieldConfigs}
-        initFormFields={initFormFields}
-        options={options}
-        onSubmit={onSubmit}
-      >
+      <FormsProvider formKey={formKey} formFieldConfigs={formFieldConfigs} options={options} onSubmit={onSubmit}>
         <Form {...passthrough}>
           <FormsConsumer>{children}</FormsConsumer>
         </Form>

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -33,8 +33,8 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsProv
   constructor(props: FormsProviderProps) {
     super(props);
 
-    // Create formFields or use initial.
-    const formFields = props.initFormFields || initializeFormFields(props.formFieldConfigs);
+    // Initialize formFields.
+    const formFields = initializeFormFields(props.formFieldConfigs);
 
     // Augment FormFields with events (helpers).
     const formFieldsState: FormFieldsState = {};
@@ -218,6 +218,10 @@ function createFormFields<F extends FormField, T extends object = any>(
       required: formFieldConfig.required || false,
       label: formFieldConfig.label,
       // Merge Config/Props and State which will overwrite any existing value in formFieldState.
+      // The "controlled" config/prop always has precedence.
+      hasError: formFieldConfig.hasError || formField.hasError,
+      errors: formFieldConfig.errors || formField.errors,
+      dirty: formFieldConfig.dirty || formField.dirty,
       helperText: formFieldConfig.helperText || formField.helperText,
     };
   });
@@ -229,12 +233,10 @@ export function initializeFormField(formFieldConfig: FormFieldConfig): FormField
   // Convert formFieldConfigs to formField.
   return {
     value: defaultInitValue(formFieldConfig),
-    // TODO: decide if setting the init value for hasError, etc is necessary.
-    // hasError: formFieldConfig.hasError || false,
-    // errors: formFieldConfig.errors || false,
-    hasError: false,
-    errors: [],
-    dirty: false,
+    hasError: formFieldConfig.hasError || false,
+    errors: formFieldConfig.errors || [],
+    dirty: formFieldConfig.dirty || false,
+    helperText: formFieldConfig.helperText,
   };
 }
 
@@ -374,7 +376,6 @@ function validateAndDetectChanges(
   formField.errors = errors.sort();
 
   const origHelperText = formField.helperText;
-  formField.helperText = formFieldConfig.helperText;
   if (formField.hasError && formFieldConfig.invalidText) {
     formField.helperText = formFieldConfig.invalidText;
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -44,8 +44,11 @@ export interface FormFieldConfig {
   validateOnChange?: boolean;
   helperText?: string; // Helper text to display. Overridden by invalidText when invalid, and getHelperText if both exist.
   invalidText?: string; // Helper text displayed on error. Overridden by getHelperText if both exist.
-  // error?: boolean;
-  // dirty?: boolean;
+
+  // Extra props used to manually control the state.
+  hasError?: boolean;
+  errors?: ErrorType[];
+  dirty?: boolean;
 
   // Validations:
   required?: boolean;
@@ -115,7 +118,6 @@ export type FormFieldsWithEventHelpers<T extends object = any> = Record<
 export interface FormsProviderProps<T extends object = any> {
   formKey?: string | number;
   formFieldConfigs: FormFieldConfig[];
-  initFormFields?: FormFields<T>;
   options?: FormOptions;
   onSubmit?(
     event: React.FormEvent<HTMLFormElement>,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -71,45 +71,67 @@ export interface FormFieldConfig {
   minLength?: number;
 
   isValid?(formField: FormField, formFields: FormFields, submitting?: boolean): boolean;
-  getHelperText?(formField: FormField, submitting?: boolean): string | undefined;
+  getHelperText?(formField: FormField, formFields: FormFields, submitting?: boolean): string | undefined;
 }
 
 export interface FormField {
-  name: string;
   value: Value;
   hasError: boolean;
   errors: ErrorType[];
-  required: boolean;
   dirty: boolean;
   helperText?: string;
+}
+
+export interface FormFieldHelpers {
+  name: string;
+  required: boolean;
   label?: string;
 }
 
-export interface FormFieldWithHelpers extends FormField {
+export interface FormFieldEventHelpers {
   onChange(event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>): void;
   onChangeChecked(event: React.ChangeEvent<HTMLInputElement>): void;
   onBlur(): void;
   onChangeValue(value: Value): void;
 }
 
+export interface FormFieldAndState extends FormField, FormFieldEventHelpers {}
+
+export interface FormFieldAndHelpers extends FormField, FormFieldHelpers {}
+
+export interface FormFieldAndEventHelpers extends FormField, FormFieldHelpers, FormFieldEventHelpers {}
+
 export type FormFields<T extends object = any> = Record<Extract<keyof T, string>, FormField>;
 
-export type FormFieldsWithHelpers<T extends object = any> = Record<Extract<keyof T, string>, FormFieldWithHelpers>;
+export type FormFieldsState<T extends object = any> = Record<Extract<keyof T, string>, FormFieldAndState>;
+
+export type FormFieldsWithHelpers<T extends object = any> = Record<Extract<keyof T, string>, FormFieldAndHelpers>;
+
+export type FormFieldsWithEventHelpers<T extends object = any> = Record<
+  Extract<keyof T, string>,
+  FormFieldAndEventHelpers
+>;
 
 export interface FormsProviderProps<T extends object = any> {
+  formKey?: string | number;
   formFieldConfigs: FormFieldConfig[];
   initFormFields?: FormFields<T>;
   options?: FormOptions;
   onSubmit?(
     event: React.FormEvent<HTMLFormElement>,
-    formFields: FormFieldsWithHelpers<T>,
+    formFields: FormFieldsWithEventHelpers<T>,
     reset: () => void,
     isDirty: () => boolean
   ): void;
 }
 
+export interface FormsProviderState<T extends object = any> {
+  formFields: FormFieldsState<T>;
+  formKey?: string | number;
+}
+
 export interface FormsContextContext<T extends object = any> {
-  formFields: FormFieldsWithHelpers<T>;
+  formFields: FormFieldsWithEventHelpers<T>;
 
   onSubmit(event: React.FormEvent<HTMLFormElement>): void;
   reset(): void;

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,7 @@
     "no-dynamic-delete": false,
     "no-empty-interface": false,
     "no-function-expression": false,
-    // TODO: allow devDependencies only in **/*.spec.ts files:
+    // SOMEDAY: allow devDependencies only in **/*.spec.ts files:
     // waiting on https://github.com/palantir/tslint/pull/3708
     "no-implicit-dependencies": [true, "dev"],
     "no-import-side-effect": false,


### PR DESCRIPTION
Add `formKey` Provider property that can be used to reset the internal formFields state and re-run validation. Useful after making an async call to update the database and you want to reset the dirty flags, etc.

Update `FormField` interface so it only contains properties that need to be managed in "state". Move the other properties to `FormFieldHelpers`

Update `FormsProvider` so it will look for `formKey` changes and re-run what we do in the constructor.

Added `updateFormFieldConfigs` flag to `validateFormFields` which can be used in server-side rendering scenarios to copy the results of the validation back to `formFieldConfigs` so they can be used to initialize the `FormsProvider`.

Add `hasError`, `errors`, and `dirty` to `FormFieldConfig` so consumer can manually control the overall Form state.

### ⚠ BREAKING CHANGES:

- Rename `createFormFields` to `initializeFormFields` so it better reflects what it does. The new `createFormFields` is now responsible for combining `FormFieldConfig` properties with `FormFieldState` to make in convenient to access all FormField related properties in one object.

- Change `getHelperText` signature so it's consistent with `isValid`.

- Renamed `FormFieldWithHelpers` to `FormFieldAndEventHelpers`, and `FormFieldsWithHelpers` to `FormFieldsWithEventHelpers`
