### PR TITLE
Better FormFieldConfig Prop Naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.3](https://github.com/cdeutsch/classy-forms/compare/v0.2.2...v0.2.3) (2020-03-18)
+
+Prepend `init` to `formFieldConfig` props that are only used during initialization.
+
+Remove the merging of certain `formFieldConfigs` and `formFields` props in `createFormFields`. There just isn't a great way to do  it. It's too hard to know which one should take precedence and when.
+
+
 ### [0.2.2](https://github.com/cdeutsch/classy-forms/compare/v0.2.1...v0.2.2) (2020-03-18)
 
 Replace `initializeFormFieldsServerSide` with `updateFormFieldConfigs` because most places using server side rendering won't be able to pass along the full augmented formFields object. It will drop any functions like `isValid`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "React Form Validation for Class based React Components",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -220,13 +220,6 @@ function createFormFields<F extends FormField, T extends object = any>(
       name: formFieldConfig.name,
       required: formFieldConfig.required || false,
       label: formFieldConfig.label,
-      // Merge Config/Props and State which will overwrite any existing value in formFieldState.
-      // The internal state has precedence over because config/props likely aren't going to detect
-      //   changes and update themselves.
-      hasError: formField.hasError !== undefined ? formField.hasError : formFieldConfig.hasError,
-      errors: formField.errors !== undefined ? formField.errors : formFieldConfig.errors,
-      dirty: formField.dirty !== undefined ? formField.dirty : formFieldConfig.dirty,
-      helperText: formField.helperText !== undefined ? formField.helperText : formFieldConfig.helperText,
     };
   });
 
@@ -237,9 +230,9 @@ export function initializeFormField(formFieldConfig: FormFieldConfig): FormField
   // Convert formFieldConfigs to formField.
   return {
     value: defaultInitValue(formFieldConfig),
-    hasError: formFieldConfig.hasError || false,
-    errors: formFieldConfig.errors || [],
-    dirty: formFieldConfig.dirty || false,
+    hasError: formFieldConfig.initHasError || false,
+    errors: formFieldConfig.initErrors || [],
+    dirty: formFieldConfig.initDirty || false,
     helperText: formFieldConfig.helperText,
   };
 }
@@ -260,10 +253,10 @@ export function updateFormFieldConfigs(formFieldConfigs: FormFieldConfig[], form
   formFieldConfigs.forEach((formFieldConfig) => {
     const formField = formFields[formFieldConfig.name];
 
-    formFieldConfig.dirty = formField.dirty;
-    formFieldConfig.errors = formField.errors;
-    formFieldConfig.hasError = formField.hasError;
     formFieldConfig.helperText = formField.helperText;
+    formFieldConfig.initDirty = formField.dirty;
+    formFieldConfig.initErrors = formField.errors;
+    formFieldConfig.initHasError = formField.hasError;
     formFieldConfig.initValue = formField.value;
   });
 }
@@ -393,6 +386,7 @@ function validateAndDetectChanges(
   formField.errors = errors.sort();
 
   const origHelperText = formField.helperText;
+  formField.helperText = formFieldConfig.helperText;
   if (formField.hasError && formFieldConfig.invalidText) {
     formField.helperText = formFieldConfig.invalidText;
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -39,16 +39,18 @@ export interface FormOptions {
 
 export interface FormFieldConfig {
   name: string;
-  initValue?: Value;
   label?: string;
   validateOnChange?: boolean;
-  helperText?: string; // Helper text to display. Overridden by invalidText when invalid, and getHelperText if both exist.
-  invalidText?: string; // Helper text displayed on error. Overridden by getHelperText if both exist.
 
-  // Extra props used to manually control the state.
-  hasError?: boolean;
-  errors?: ErrorType[];
-  dirty?: boolean;
+  // Props used to initialize FormFields:
+  initValue?: Value;
+  initHasError?: boolean;
+  initErrors?: ErrorType[];
+  initDirty?: boolean;
+
+  // Helper Text:
+  helperText?: string; // Helper text to display on validation. Overridden by invalidText when invalid, and getHelperText if both exist.
+  invalidText?: string; // Helper text displayed on error. Overridden by getHelperText if both exist.
 
   // Validations:
   required?: boolean;


### PR DESCRIPTION
Prepend `init` to `formFieldConfig` props that are only used during initialization.

Remove the merging of certain `formFieldConfigs` and `formFields` props in `createFormFields`. There just isn't a great way to do  it. It's too hard to know which one should take precedence and when.