### PR TITLE
Stop propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.0.0](https://github.com/cdeutsch/classy-forms/compare/v0.3.2...v1.0.0) (2020-07-07)
+
+Stop propagation in case we're in a React Portal, because portals propagate events along the React component hierarchy, not the DOM hierarchy.
+
+
 ### [0.3.2](https://github.com/cdeutsch/classy-forms/compare/v0.3.1...v0.3.2) (2020-04-06)
 
 Provide a `validate` function to be used when you're not using a regular `<form>`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "0.3.2",
+  "version": "1.0.0",
   "description": "React Form Validation for Class based React Components",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/FormsProvider.tsx
+++ b/src/FormsProvider.tsx
@@ -176,6 +176,10 @@ export class FormsProvider extends React.Component<FormsProviderProps, FormsProv
     } else {
       // Prevent <form> from submitting.
       event.preventDefault();
+      // Stop propagation in case we're in a React Portal, because
+      // portals propagate events along the React component hierarchy, not the DOM hierarchy 🤦️
+      // https://github.com/facebook/react/issues/11387
+      event.stopPropagation();
     }
   };
 


### PR DESCRIPTION
Stop propagation in case we're in a React Portal, because portals stupidly propagate events along the React component hierarchy, not the DOM hierarchy 🤦️

https://github.com/facebook/react/issues/11387