### PR TITLE
isInitError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.1.7](https://github.com/cdeutsch/classy-forms/compare/v2.1.6...v2.1.7) (2022-04-15)
+
+Add `isInitError` which will maintain `initHasError` during the constructor.
+
+Otherwise if you set `initHasError` based on a server condition that isn't checked inside `isValid`, the error state will immediately be lost.
+
+This could be considered a breaking change since `initHasError` will behave different, but it's also a bug fix.
+
+
 ### [2.1.6](https://github.com/cdeutsch/classy-forms/compare/v2.1.5...v2.1.6) (2022-04-14)
 
 Fix bug with iterating over `FormData` keys.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "classy-forms",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.1.6",
+      "version": "2.1.7",
       "license": "MIT",
       "devDependencies": {
         "@babel/plugin-proposal-class-properties": "^7.16.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "classy-forms",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "React Form Validation for Class based React Components",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,7 +22,8 @@ export type ErrorType =
   | 'maxLength'
   | 'minLength'
   | 'required'
-  | 'isValid';
+  | 'isValid'
+  | 'isInitError';
 
 export type DirtyMode = 'NotEqual' | 'OnChange';
 


### PR DESCRIPTION
Add `isInitError` which will maintain `initHasError` during the constructor. 

Otherwise if you set `initHasError` based on a server condition that isn't checked inside `isValid`, the error state will immediately be lost.

This could be considered a breaking change since `initHasError` will behave different, but it's also a bug fix.